### PR TITLE
feat: add getPeer per rinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ srv.close([cb]);
 
 Shuts down the server and calls `cb` once the underlying socket has been closed.
 
+#### Method: getPeer(rinfo): peer
+
+```js
+srv.getPeer({address: ..., port: ...});
+```
+
+Returns a peer by address & port.
+
 #### Event: connection
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openssl-dtls",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Bindings for OpenSSL DTLS1.2",
   "main": "index.js",
   "author": "Jue <me@jue.yt>",

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ class Server extends EventEmitter {
 
 		// Listen for datagrams
 		this.socket.on('message', (message, rinfo) => {
-			const key = `${rinfo.address} ${rinfo.port}`;
+			const key = this._peerKey(rinfo);
 
 			// New connection
 			if (!this.peers[key]) {
@@ -66,6 +66,15 @@ class Server extends EventEmitter {
 
 			this.peers[key]._handler(message);
 		});
+	}
+
+	_peerKey (rinfo) {
+		return `${rinfo.address} ${rinfo.port}`;
+	}
+
+	getPeer (rinfo) {
+		const key = this._peerKey(rinfo)
+		return this.peers[key]
 	}
 
 	bind () {


### PR DESCRIPTION
In order to use this package as a proxy without opening one backend socket per peer (and thus make the proxy scale above the number of available ports), being able to access peers per socket remote info is needed.

Here is the code I am writing  in order to integrate this project with https://github.com/coapjs/node-coap (see https://github.com/coapjs/node-coap/issues/253) and where we see this need of the method added in the pull request:

```javascript
import { createServer } from "openssl-dtls"
import { EventEmitter } from "events"

export class DTLSSocket extends EventEmitter {
  constructor(options) {
    super()
    this.dtlsServer = createServer(options)

    this.dtlsServer.on("secureConnection", peer => {
      peer.on("message", msg => {
        this.emit("message", msg, peer.address())
      })
    })
  }

  send(message, port, host, callback) {
    // here I duplicate https://github.com/jue89/node-openssl-dtls/blob/7e16a03d504d72d0d7027a7111e6a21f79ca3692/server.js#L51
    const key = `${host} ${port}`
    const peer = this.dtlsServer.peers[key]

    if (peer) {
      peer.send(message)
      callback()
    } else {
      callback(new Error('No client connection stored at this address'))
    }
  }
}
```